### PR TITLE
Fix #9 (domain validation fails when the domains in question need to get the same TXT record populated)

### DIFF
--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -162,7 +162,7 @@ class Authenticator(dns_common.DNSAuthenticator):
                 zone_name=azure_domain,
                 relative_record_set_name=relative_validation_name,
                 record_type='TXT',
-                parameters=RecordSet(ttl=self.ttl, txt_records=[TxtRecord(value=list(txt_value))])
+                parameters=RecordSet(ttl=self.ttl, txt_records=[TxtRecord(value=[v]) for v in txt_value])
             )
         except HttpResponseError as err:
             raise errors.PluginError('Failed to add TXT record to domain '


### PR DESCRIPTION
This patch fixes issue #9.